### PR TITLE
Disabled user support

### DIFF
--- a/docs/resources/sensu_user.md
+++ b/docs/resources/sensu_user.md
@@ -15,8 +15,11 @@ resource "sensu_user" "user_1" {
   name = "my_user"
   password = "abcd1234"
   groups = ["admin"]
+  disabled = false
 }
 ```
+
+_Note_: if user already exist, it will be re-enabled and updated with resource data.
 
 ## Argument Reference
 
@@ -25,6 +28,8 @@ resource "sensu_user" "user_1" {
 * `password` - *Required* - See the [Sensu rbac reference](https://docs.sensu.io/sensu-go/5.0/reference/rbac/#user).
 
 * `groups` - *Optional* - See the [Sensu rbac reference](https://docs.sensu.io/sensu-go/5.0/reference/rbac/#user).
+
+* `disabled` - *Optional* - See the [Sensu rbac reference](https://docs.sensu.io/sensu-go/5.0/reference/rbac/#user).
 
 ## Attribute Reference
 

--- a/sensu/data_user.go
+++ b/sensu/data_user.go
@@ -20,6 +20,11 @@ func dataSourceUser() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
+			"disabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -36,6 +41,7 @@ func dataSourceUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", name)
 	d.Set("groups", user.Groups)
+	d.Set("disabled", user.Disabled)
 
 	d.SetId(name)
 

--- a/sensu/data_user_test.go
+++ b/sensu/data_user_test.go
@@ -20,6 +20,8 @@ func TestAccDataSourceUser_basic(t *testing.T) {
 						"data.sensu_user.user_1", "groups.#", "1"),
 					resource.TestCheckResourceAttr(
 						"data.sensu_user.user_1", "groups.0", "cluster-admins"),
+					resource.TestCheckResourceAttr(
+						"data.sensu_user.user_1", "disabled", "false"),
 				),
 			},
 		},

--- a/sensu/data_user_test.go
+++ b/sensu/data_user_test.go
@@ -20,8 +20,6 @@ func TestAccDataSourceUser_basic(t *testing.T) {
 						"data.sensu_user.user_1", "groups.#", "1"),
 					resource.TestCheckResourceAttr(
 						"data.sensu_user.user_1", "groups.0", "cluster-admins"),
-					resource.TestCheckResourceAttr(
-						"data.sensu_user.user_1", "disabled", "false"),
 				),
 			},
 		},

--- a/sensu/resource_user.go
+++ b/sensu/resource_user.go
@@ -98,48 +98,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if d.HasChange("groups") {
-		o, n := d.GetChange("groups")
-		oldGroups := expandStringList(o.([]interface{}))
-		newGroups := expandStringList(n.([]interface{}))
-
-		// first remove all old groups
-		for _, oldGroup := range oldGroups {
-			err := config.client.RemoveGroupFromUser(name, oldGroup)
-			if err != nil {
-				return fmt.Errorf("Unable to remove group %s from user %s: %s", oldGroup, name, err)
-			}
-		}
-
-		// next add all groups
-		for _, newGroup := range newGroups {
-			err := config.client.AddGroupToUser(name, newGroup)
-			if err != nil {
-				return fmt.Errorf("Unable to add group %s to user %s: %s", newGroup, name, err)
-			}
-		}
-	}
-
-	if d.HasChange("password") {
-		password := d.Get("password").(string)
-		if err := config.client.UpdatePassword(name, password); err != nil {
-			return fmt.Errorf("Unable to update password for user %s: %s", name, err)
-		}
-	}
-
-
-	if d.HasChange("disabled") {
-		disabled := d.Get("disabled").(bool)
-		if disabled {
-			if err := config.client.DisableUser(name); err != nil {
-				return fmt.Errorf("Unable to disable user %s: %s", name, err)
-			}
-		} else {
-			if err := config.client.ReinstateUser(name); err != nil {
-				return fmt.Errorf("Unable to reinstate user %s: %s", name, err)
-			}
-		}
-	}
+	updateUser(d, meta)
 
 	return resourceUserRead(d, meta)
 }
@@ -188,42 +147,48 @@ func updateUser(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	name := d.Id()
 
-	o, n := d.GetChange("groups")
-	oldGroups := expandStringList(o.([]interface{}))
-	newGroups := expandStringList(n.([]interface{}))
+	if d.HasChange("groups") {
+		o, n := d.GetChange("groups")
+		oldGroups := expandStringList(o.([]interface{}))
+		newGroups := expandStringList(n.([]interface{}))
 
-	// first remove all old groups
-	for _, oldGroup := range oldGroups {
-		err := config.client.RemoveGroupFromUser(name, oldGroup)
-		if err != nil {
-			return fmt.Errorf("Unable to remove group %s from user %s: %s", oldGroup, name, err)
+		// first remove all old groups
+		for _, oldGroup := range oldGroups {
+			err := config.client.RemoveGroupFromUser(name, oldGroup)
+			if err != nil {
+				return fmt.Errorf("Unable to remove group %s from user %s: %s", oldGroup, name, err)
+			}
+		}
+
+		// next add all groups
+		for _, newGroup := range newGroups {
+			err := config.client.AddGroupToUser(name, newGroup)
+			if err != nil {
+				return fmt.Errorf("Unable to add group %s to user %s: %s", newGroup, name, err)
+			}
 		}
 	}
 
-	// next add all groups
-	for _, newGroup := range newGroups {
-		err := config.client.AddGroupToUser(name, newGroup)
-		if err != nil {
-			return fmt.Errorf("Unable to add group %s to user %s: %s", newGroup, name, err)
+	if d.HasChange("password") {
+		password := d.Get("password").(string)
+		if err := config.client.UpdatePassword(name, password); err != nil {
+			return fmt.Errorf("Unable to update password for user %s: %s", name, err)
 		}
 	}
 
-	password := d.Get("password").(string)
-	if err := config.client.UpdatePassword(name, password); err != nil {
-		return fmt.Errorf("Unable to update password for user %s: %s", name, err)
-	}
 
-
-	disabled := d.Get("disabled").(bool)
-	if disabled {
-		if err := config.client.DisableUser(name); err != nil {
-			return fmt.Errorf("Unable to disable user %s: %s", name, err)
-		}
-	} else {
-		if err := config.client.ReinstateUser(name); err != nil {
-			return fmt.Errorf("Unable to reinstate user %s: %s", name, err)
+	if d.HasChange("disabled") {
+		disabled := d.Get("disabled").(bool)
+		if disabled {
+			if err := config.client.DisableUser(name); err != nil {
+				return fmt.Errorf("Unable to disable user %s: %s", name, err)
+			}
+		} else {
+			if err := config.client.ReinstateUser(name); err != nil {
+				return fmt.Errorf("Unable to reinstate user %s: %s", name, err)
+			}
 		}
 	}
 
-	return resourceUserRead(d, meta)
+	return nil
 }

--- a/sensu/resource_user.go
+++ b/sensu/resource_user.go
@@ -54,6 +54,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 			Username: name,
 			Password: d.Get("password").(string),
 			Groups:   groups,
+			Disabled: d.Get("disabled").(bool),
 		}
 
 		log.Printf("[DEBUG] Creating user %s: %#v", name, user)
@@ -85,6 +86,7 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", name)
 	d.Set("groups", user.Groups)
+	d.Set("disabled", user.Disabled)
 
 	return nil
 }
@@ -174,7 +176,6 @@ func updateUser(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Unable to update password for user %s: %s", name, err)
 		}
 	}
-
 
 	if d.HasChange("disabled") {
 		disabled := d.Get("disabled").(bool)

--- a/sensu/resource_user.go
+++ b/sensu/resource_user.go
@@ -90,7 +90,6 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
 	name := d.Id()
 
 	_, err := findUser(meta, name)

--- a/sensu/resource_user.go
+++ b/sensu/resource_user.go
@@ -27,8 +27,12 @@ func resourceUser() *schema.Resource {
 				Required:  true,
 				Sensitive: true,
 			},
-
 			// Optional
+			"disabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"groups": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -40,26 +44,31 @@ func resourceUser() *schema.Resource {
 
 func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	name := d.Get("name").(string)
+	d.SetId(d.Get("name").(string))
+	name := d.Id()
 
-	groups := expandStringList(d.Get("groups").([]interface{}))
-	user := &types.User{
-		Username: name,
-		Password: d.Get("password").(string),
-		Groups:   groups,
+	_, err := findUser(meta, name)
+	if err != nil {
+		groups := expandStringList(d.Get("groups").([]interface{}))
+		user := &types.User{
+			Username: name,
+			Password: d.Get("password").(string),
+			Groups:   groups,
+		}
+
+		log.Printf("[DEBUG] Creating user %s: %#v", name, user)
+
+		if err := user.Validate(); err != nil {
+			return fmt.Errorf("Invalid user %s: %s", name, err)
+		}
+
+		if err := config.client.CreateUser(user); err != nil {
+			return fmt.Errorf("Error creating user %s: %s", name, err)
+		}
+	} else {
+		log.Printf("[DEBUG] Updating user %s", name)
+		updateUser(d, meta)
 	}
-
-	log.Printf("[DEBUG] Creating user %s: %#v", name, user)
-
-	if err := user.Validate(); err != nil {
-		return fmt.Errorf("Invalid user %s: %s", name, err)
-	}
-
-	if err := config.client.CreateUser(user); err != nil {
-		return fmt.Errorf("Error creating user %s: %s", name, err)
-	}
-
-	d.SetId(name)
 
 	return resourceUserRead(d, meta)
 }
@@ -118,20 +127,19 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	/*
-		if d.HasChange("disabled") {
-			disabled := d.Get("disabled").(bool)
-			if disabled {
-				if err := config.client.DisableUser(name); err != nil {
-					return fmt.Errorf("Unable to disable user %s: %s", name, err)
-				}
-			} else {
-				if err := config.client.ReinstateUser(name); err != nil {
-					return fmt.Errorf("Unable to reinstate user %s: %s", name, err)
-				}
+
+	if d.HasChange("disabled") {
+		disabled := d.Get("disabled").(bool)
+		if disabled {
+			if err := config.client.DisableUser(name); err != nil {
+				return fmt.Errorf("Unable to disable user %s: %s", name, err)
+			}
+		} else {
+			if err := config.client.ReinstateUser(name); err != nil {
+				return fmt.Errorf("Unable to reinstate user %s: %s", name, err)
 			}
 		}
-	*/
+	}
 
 	return resourceUserRead(d, meta)
 }
@@ -174,4 +182,48 @@ func findUser(meta interface{}, name string) (*types.User, error) {
 	}
 
 	return &user, nil
+}
+
+func updateUser(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	name := d.Id()
+
+	o, n := d.GetChange("groups")
+	oldGroups := expandStringList(o.([]interface{}))
+	newGroups := expandStringList(n.([]interface{}))
+
+	// first remove all old groups
+	for _, oldGroup := range oldGroups {
+		err := config.client.RemoveGroupFromUser(name, oldGroup)
+		if err != nil {
+			return fmt.Errorf("Unable to remove group %s from user %s: %s", oldGroup, name, err)
+		}
+	}
+
+	// next add all groups
+	for _, newGroup := range newGroups {
+		err := config.client.AddGroupToUser(name, newGroup)
+		if err != nil {
+			return fmt.Errorf("Unable to add group %s to user %s: %s", newGroup, name, err)
+		}
+	}
+
+	password := d.Get("password").(string)
+	if err := config.client.UpdatePassword(name, password); err != nil {
+		return fmt.Errorf("Unable to update password for user %s: %s", name, err)
+	}
+
+
+	disabled := d.Get("disabled").(bool)
+	if disabled {
+		if err := config.client.DisableUser(name); err != nil {
+			return fmt.Errorf("Unable to disable user %s: %s", name, err)
+		}
+	} else {
+		if err := config.client.ReinstateUser(name); err != nil {
+			return fmt.Errorf("Unable to reinstate user %s: %s", name, err)
+		}
+	}
+
+	return resourceUserRead(d, meta)
 }

--- a/sensu/resource_user_test.go
+++ b/sensu/resource_user_test.go
@@ -22,6 +22,8 @@ func TestAccResourceUser_basic(t *testing.T) {
 						"sensu_user.user_1", "name", username),
 					resource.TestCheckResourceAttr(
 						"sensu_user.user_1", "groups.#", "1"),
+					resource.TestCheckResourceAttr(
+						"sensu_user.user_1", "disabled", "false"),
 				),
 			},
 			resource.TestStep{
@@ -31,6 +33,8 @@ func TestAccResourceUser_basic(t *testing.T) {
 						"sensu_user.user_1", "name", username),
 					resource.TestCheckResourceAttr(
 						"sensu_user.user_1", "groups.#", "2"),
+					resource.TestCheckResourceAttr(
+						"sensu_user.user_1", "disabled", "false"),
 				),
 			},
 		},
@@ -62,12 +66,31 @@ func TestAccResourceUser_password(t *testing.T) {
 	})
 }
 
+func TestAccResourceUser_disabled(t *testing.T) {
+	username := acctest.RandomWithPrefix("sensu-acctest")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccResourceUser_disabled(username),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"sensu_user.user_1", "name", username),
+				),
+			},
+		},
+	})
+}
+
 func testAccResourceUser_basic(username string) string {
 	return fmt.Sprintf(`
 		resource "sensu_user" "user_1" {
 			name = "%s"
 			password = "abcd1234"
 			groups = ["admin"]
+			disabled = "false"
 		}
 	`, username)
 }
@@ -78,6 +101,7 @@ func testAccResourceUser_update(username string) string {
 			name = "%s"
 			password = "abcd1234"
 			groups = ["admin", "read-only"]
+			disabled = "false"
 		}
 	`, username)
 }
@@ -98,6 +122,17 @@ func testAccResourceUser_password_2(username string) string {
 			name = "%s"
 			password = "1234abcd"
 			groups = ["admin"]
+		}
+	`, username)
+}
+
+func testAccResourceUser_disabled(username string) string {
+	return fmt.Sprintf(`
+		resource "sensu_user" "user_1" {
+			name = "%s"
+			password = "1234abcd"
+			groups = ["admin"]
+			disabled = "true"
 		}
 	`, username)
 }

--- a/sensu/resource_user_test.go
+++ b/sensu/resource_user_test.go
@@ -22,6 +22,8 @@ func TestAccResourceUser_basic(t *testing.T) {
 						"sensu_user.user_1", "name", username),
 					resource.TestCheckResourceAttr(
 						"sensu_user.user_1", "groups.#", "1"),
+					resource.TestCheckResourceAttr(
+						"sensu_user.user_1", "disabled", "false"),
 				),
 			},
 			resource.TestStep{
@@ -31,6 +33,8 @@ func TestAccResourceUser_basic(t *testing.T) {
 						"sensu_user.user_1", "name", username),
 					resource.TestCheckResourceAttr(
 						"sensu_user.user_1", "groups.#", "2"),
+					resource.TestCheckResourceAttr(
+						"sensu_user.user_1", "disabled", "false"),
 				),
 			},
 		},
@@ -86,6 +90,7 @@ func testAccResourceUser_basic(username string) string {
 			name = "%s"
 			password = "abcd1234"
 			groups = ["admin"]
+			disabled = false
 		}
 	`, username)
 }
@@ -96,6 +101,7 @@ func testAccResourceUser_update(username string) string {
 			name = "%s"
 			password = "abcd1234"
 			groups = ["admin", "read-only"]
+			disabled = false
 		}
 	`, username)
 }
@@ -106,6 +112,7 @@ func testAccResourceUser_password_1(username string) string {
 			name = "%s"
 			password = "abcd1234"
 			groups = ["admin"]
+			disabled = false
 		}
 	`, username)
 }
@@ -116,6 +123,7 @@ func testAccResourceUser_password_2(username string) string {
 			name = "%s"
 			password = "1234abcd"
 			groups = ["admin"]
+			disabled = false
 		}
 	`, username)
 }

--- a/sensu/resource_user_test.go
+++ b/sensu/resource_user_test.go
@@ -22,8 +22,6 @@ func TestAccResourceUser_basic(t *testing.T) {
 						"sensu_user.user_1", "name", username),
 					resource.TestCheckResourceAttr(
 						"sensu_user.user_1", "groups.#", "1"),
-					resource.TestCheckResourceAttr(
-						"sensu_user.user_1", "disabled", "false"),
 				),
 			},
 			resource.TestStep{
@@ -33,8 +31,6 @@ func TestAccResourceUser_basic(t *testing.T) {
 						"sensu_user.user_1", "name", username),
 					resource.TestCheckResourceAttr(
 						"sensu_user.user_1", "groups.#", "2"),
-					resource.TestCheckResourceAttr(
-						"sensu_user.user_1", "disabled", "false"),
 				),
 			},
 		},
@@ -90,7 +86,6 @@ func testAccResourceUser_basic(username string) string {
 			name = "%s"
 			password = "abcd1234"
 			groups = ["admin"]
-			disabled = "false"
 		}
 	`, username)
 }
@@ -101,7 +96,6 @@ func testAccResourceUser_update(username string) string {
 			name = "%s"
 			password = "abcd1234"
 			groups = ["admin", "read-only"]
-			disabled = "false"
 		}
 	`, username)
 }
@@ -132,7 +126,7 @@ func testAccResourceUser_disabled(username string) string {
 			name = "%s"
 			password = "1234abcd"
 			groups = ["admin"]
-			disabled = "true"
+			disabled = true
 		}
 	`, username)
 }


### PR DESCRIPTION
Hi,

As described in the sensu documentation user are never deleted but disabled.

We want that the sensu provider manage disabled user. In order to avoid the error message "resource already exists", we want to re-enabled user and update his password and groups if needed.

Does it seems suitable for you ?
