### PR TITLE
fix resource check handers update

### DIFF
--- a/sensu/resource_check.go
+++ b/sensu/resource_check.go
@@ -355,7 +355,7 @@ func resourceCheckUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("handlers") {
-		handlers := expandStringList(d.Get("handlers").(*schema.Set).List())
+		handlers := expandStringList(d.Get("handlers").([]interface{}))
 		check.Handlers = handlers
 	}
 


### PR DESCRIPTION
Hi again,

When updating an resource check handler, terraform crash with this errror:

`panic: interface conversion: interface {} is []interface {}, not *schema.Set`

It's better to update instead of delete/create ;-)