### PR TITLE
add tls provider options

### DIFF
--- a/sensu/config.go
+++ b/sensu/config.go
@@ -111,18 +111,12 @@ func (c *Config) SaveTokens(tokens *types.Tokens) error {
 
 // InsecureSkipTLSVerify implements the InsecureSkipTLSVerify method for the
 // config.Config interface.
-//
-// Note: this is not actually implemented in this provider. This is only
-// used to satisfy the Sensu client interface.
 func (c *Config) InsecureSkipTLSVerify() bool {
 	return c.insecureSkipTLSVerify
 }
 
 // SaveInsecureSkipTLSVerify implements the SaveInsecureSkipTLSVerify method
 // for the config.Config interface.
-//
-// Note: this is not actually implemented in this provider. This is only
-// used to satisfy the Sensu client interface.
 func (c *Config) SaveInsecureSkipTLSVerify(v bool) error {
 	c.insecureSkipTLSVerify = v
 	return nil
@@ -130,18 +124,12 @@ func (c *Config) SaveInsecureSkipTLSVerify(v bool) error {
 
 // TrustedCAFile implements the TrustedCAFile method for the config.Config
 // interface.
-//
-// Note: this is not actually implemented in this provider. This is only
-// used to satisfy the Sensu client interface.
 func (c *Config) TrustedCAFile() string {
 	return c.trustedCAFile
 }
 
 // SaveTrustedCAFile implements the SaveTrustedCAFile method for the
 // config.Config interface.
-//
-// Note: this is not actually implemented in this provider. This is only
-// used to satisfy the Sensu client interface.
 func (c *Config) SaveTrustedCAFile(v string) error {
 	c.trustedCAFile = v
 	return nil

--- a/sensu/provider.go
+++ b/sensu/provider.go
@@ -39,6 +39,18 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SENSU_EDITION", ""),
 			},
+
+			"trusted_ca_file": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SENSU_TRUSTED_CA_FILE", ""),
+			},
+
+			"insecure_skip_tls_verify": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SENSU_INSECURE_SKIP_TLS_VERIFY", false),
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -74,11 +86,13 @@ func Provider() terraform.ResourceProvider {
 
 func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		apiUrl:    d.Get("api_url").(string),
-		username:  d.Get("username").(string),
-		password:  d.Get("password").(string),
-		edition:   d.Get("edition").(string),
-		namespace: d.Get("namespace").(string),
+		apiUrl:                d.Get("api_url").(string),
+		username:              d.Get("username").(string),
+		password:              d.Get("password").(string),
+		edition:               d.Get("edition").(string),
+		namespace:             d.Get("namespace").(string),
+		trustedCAFile:         d.Get("trusted_ca_file").(string),
+		insecureSkipTLSVerify: d.Get("insecure_skip_tls_verify").(bool),
 	}
 
 	if err := config.LoadAndValidate(); err != nil {

--- a/vendor/github.com/sensu/sensu-go/cli/client/config/config.go
+++ b/vendor/github.com/sensu/sensu-go/cli/client/config/config.go
@@ -35,14 +35,18 @@ type Config interface {
 type Read interface {
 	APIUrl() string
 	Format() string
+	InsecureSkipTLSVerify() bool
 	Namespace() string
 	Tokens() *types.Tokens
+	TrustedCAFile() string
 }
 
 // Write contains all methods related to setting and writting configuration
 type Write interface {
 	SaveAPIUrl(string) error
 	SaveFormat(string) error
+	SaveInsecureSkipTLSVerify(bool) error
 	SaveNamespace(string) error
 	SaveTokens(*types.Tokens) error
+	SaveTrustedCAFile(string) error
 }


### PR DESCRIPTION
Added support for the following TLS related options to the sensu provider: `trusted_ca_file` and `insecure_skip_tls_verify`. 
This allows usage of a self-signed certificate without adding it to the operating
system's CA store, either by explicitly trusting the signer, or by disabling TLS hostname verification.

Hi @jtopjian 

I don't want to stay on a failure, so I try again after your last PR but It doesn't work. I miss something cause even I pass the option `insecure_skip_tls_verify = true` I always have the error:
`Error: Get "https://sensu_host:8080/auth": x509: certificate signed by unknown authority`

It seems that the option is not taken by the rest client.
Also I'm not sure to really understand if the modification in the vendor folder must be done here, but I tried to build with `env GOFLAGS=-mod=vendor` and it's the same error.

Could you take some times to help me on this ?

Thanks