### PR TITLE
fix check attributes output_metric_*

### DIFF
--- a/sensu/resource_check.go
+++ b/sensu/resource_check.go
@@ -402,11 +402,11 @@ func resourceCheckUpdate(d *schema.ResourceData, meta interface{}) error {
 		check.LowFlapThreshold = uint32(d.Get("low_flap_threshold").(int))
 	}
 
-	if d.HasChange("metric_format") {
+	if d.HasChange("output_metric_format") {
 		check.OutputMetricFormat = d.Get("output_metric_format").(string)
 	}
 
-	if d.HasChange("metric_handlers") {
+	if d.HasChange("output_metric_handlers") {
 		metricHandlers := expandStringList(d.Get("output_metric_handlers").([]interface{}))
 		check.OutputMetricHandlers = metricHandlers
 	}


### PR DESCRIPTION
Hi @jtopjian,

Theses attributes are not updated when updating the sensu check resource.

`+ output_metric_format   = "graphite_plaintext"`
`~ output_metric_handlers = [`
`    - "graphite_handler",`
`    + "my_graphite_handler",`
`  ]`

It's just an typo error, I think.