### PR TITLE
Support of sensu silencing

### DIFF
--- a/docs/data_sources/sensu_silenced.md
+++ b/docs/data_sources/sensu_silenced.md
@@ -1,0 +1,33 @@
+# sensu_silenced
+
+Get information about a Sensu Silencing.
+
+For full documentation on Sensu Silencing, see [here](https://docs.sensu.io/sensu-go/latest/reference/silencing).
+
+## Basic Example
+
+```hcl
+data "sensu_silenced" "silence_1" {
+  check = "foo"
+  subscription = "entity:bar"
+}
+```
+
+## Argument Reference
+
+* `check` - *Required* - The name of the check the entry should match
+
+* `subscription` - *Required* - The name of the subscription the entry should match.
+
+* `namespace` - *Optional* - The namespace to manage resources in. This can
+  also be set with the `SENSU_NAMESPACE` environment variable. If not set,
+  this defaults to `default`.
+
+## Attribute Reference
+
+* `begin` - See the [Sensu silence reference](https://docs.sensu.io/sensu-go/latest/reference/silencing/#spec-attributes).
+* `expire` - See the [Sensu silence reference](https://docs.sensu.io/sensu-go/latest/reference/silencing/#spec-attributes). 
+* `expire_on_resolve` - See the [Sensu silence reference](https://docs.sensu.io/sensu-go/latest/reference/silencing/#spec-attributes). 
+* `reason` - See the [Sensu silence reference](https://docs.sensu.io/sensu-go/latest/reference/silencing/#spec-attributes). 
+* `labels` - See the [Sensu silence reference](https://docs.sensu.io/sensu-go/latest/reference/silencing/#metadata-attributes). 
+* `annotations` - See the [Sensu silence reference](https://docs.sensu.io/sensu-go/latest/reference/silencing/#metadata-attributes).

--- a/docs/resources/sensu_silenced.md
+++ b/docs/resources/sensu_silenced.md
@@ -1,0 +1,43 @@
+# sensu_silenced
+
+Get information about a Sensu Silencing.
+
+For full documentation on Sensu Silencing, see [here](https://docs.sensu.io/sensu-go/latest/reference/silencing).
+
+## Basic Example
+
+```hcl
+resource "sensu_silenced" "silence_1" {
+  check = "foo"
+  subscription = "entity:bar"
+  begin = "Jun 02 2020 3:04PM MST"
+}
+```
+
+## Argument Reference
+
+* `check` - *Required* - The name of the check the entry should match
+
+* `subscription` - *Required* - The name of the subscription the entry should match.
+
+* `namespace` - *Optional* - The namespace to manage resources in. This can
+  also be set with the `SENSU_NAMESPACE` environment variable. If not set,
+  this defaults to `default`.
+
+* `begin` - *Optional* - Time at which silence entry goes into effect
+  in human readable time (Format: Jan 02 2006 3:04PM MST)". If not set,
+  this defaults to `now`.
+
+* `expire` - *Optional* - See the [Sensu silence reference](https://docs.sensu.io/sensu-go/latest/reference/silencing/#spec-attributes). 
+
+* `expire_on_resolve` - *Optional* - See the [Sensu silence reference](https://docs.sensu.io/sensu-go/latest/reference/silencing/#spec-attributes).
+
+* `reason` - *Optional* - See the [Sensu silence reference](https://docs.sensu.io/sensu-go/latest/reference/silencing/#spec-attributes). 
+
+* `labels` - *Optional* - See the [Sensu silence reference](https://docs.sensu.io/sensu-go/latest/reference/silencing/#metadata-attributes). 
+
+* `annotations` - *Optional* - See the [Sensu silence reference](https://docs.sensu.io/sensu-go/latest/reference/silencing/#metadata-attributes).
+
+## Attribute Reference
+
+The resource has no computed fields.

--- a/sensu/data_silenced.go
+++ b/sensu/data_silenced.go
@@ -1,0 +1,89 @@
+package sensu
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceSilenced() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceSilencedRead,
+
+		Schema: map[string]*schema.Schema{
+			// Required
+			"check": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"subscription": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// Optional
+			"namespace": resourceNamespaceSchema,
+
+			// Computed
+			"annotations": &schema.Schema{
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+
+			"labels": &schema.Schema{
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+
+			"begin": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"expire": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"expire_on_resolve": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"reason": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceSilencedRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	config.SaveNamespace(config.determineNamespace(d))
+	check := d.Get("check").(string)
+	subscription := d.Get("subscription").(string)
+	name := fmt.Sprintf("%s:%s", subscription, check)
+
+	silenced, err := config.client.FetchSilenced(name)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve silenced %s: %s", name, err)
+	}
+
+	log.Printf("[DEBUG] Retrieved silenced %s: %#v", name, silenced)
+
+	d.SetId(silenced.Name)
+	d.Set("namespace", silenced.ObjectMeta.Namespace)
+	d.Set("annotations", silenced.ObjectMeta.Annotations)
+	d.Set("labels", silenced.ObjectMeta.Labels)
+	d.Set("begin", silenced.Begin)
+	d.Set("check", silenced.Check)
+	d.Set("subscription", silenced.Subscription)
+	d.Set("resolve", silenced.ExpireOnResolve)
+	d.Set("expire", silenced.Expire)
+	d.Set("reason", silenced.Reason)
+
+	return nil
+}

--- a/sensu/data_silenced_test.go
+++ b/sensu/data_silenced_test.go
@@ -1,0 +1,35 @@
+package sensu
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceSilenced_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceSilenced_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.sensu_silenced.silenced_1", "check", "check_1"),
+					resource.TestCheckResourceAttr(
+						"data.sensu_silenced.silenced_1", "subscription", "subscription_1"),
+				),
+			},
+		},
+	})
+}
+
+var testAccDataSourceSilenced_basic = fmt.Sprintf(`
+  %s
+
+  data "sensu_silenced" "silenced_1" {
+	check = "${sensu_silenced.silenced_1.check}"
+    subscription = "${sensu_silenced.silenced_1.subscription}"
+  }
+`, testAccResourceSilenced_basic)

--- a/sensu/import_silenced_test.go
+++ b/sensu/import_silenced_test.go
@@ -1,0 +1,31 @@
+package sensu
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccImportSilenced_basic(t *testing.T) {
+	resourceName := "sensu_silenced.silenced_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccResourceSilenced_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"begin",
+					"expire_on_resolve",
+				},
+			},
+		},
+	})
+}

--- a/sensu/provider.go
+++ b/sensu/provider.go
@@ -63,6 +63,7 @@ func Provider() terraform.ResourceProvider {
 			"sensu_namespace":    dataSourceNamespace(),
 			"sensu_role":         dataSourceRole(),
 			"sensu_role_binding": dataSourceRoleBinding(),
+			"sensu_silenced":     dataSourceSilenced(),
 			"sensu_user":         dataSourceUser(),
 		},
 
@@ -76,6 +77,7 @@ func Provider() terraform.ResourceProvider {
 			"sensu_namespace":    resourceNamespace(),
 			"sensu_role":         resourceRole(),
 			"sensu_role_binding": resourceRoleBinding(),
+			"sensu_silenced":     resourceSilenced(),
 			"sensu_user":         resourceUser(),
 		},
 

--- a/sensu/resource_silenced.go
+++ b/sensu/resource_silenced.go
@@ -1,0 +1,232 @@
+package sensu
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/sensu/sensu-go/cli/commands/timeutil"
+	"github.com/sensu/sensu-go/types"
+)
+
+func resourceSilenced() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSilencedCreate,
+		Read:   resourceSilencedRead,
+		Update: resourceSilencedUpdate,
+		Delete: resourceSilencedDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			// Required
+			"check": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"subscription": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			// Optional
+			"begin": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "now",
+			},
+
+			"expire": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+
+			"expire_on_resolve": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"reason": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"labels": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+
+			"annotations": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+
+			"namespace": resourceNamespaceSchema,
+		},
+	}
+}
+
+func resourceSilencedCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	check := d.Get("check").(string)
+	subscription := d.Get("subscription").(string)
+	name := fmt.Sprintf("%s:%s", subscription, check)
+
+	annotations := expandAnnotations(d.Get("annotations").(map[string]interface{}))
+	labels := expandLabels(d.Get("labels").(map[string]interface{}))
+
+	begin, err := beginConvertToTimestamp(d.Get("begin").(string))
+	if err != nil {
+		return err
+	}
+
+	silenced := &types.Silenced{
+		ObjectMeta: types.ObjectMeta{
+			Name:        name,
+			Namespace:   config.determineNamespace(d),
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		Begin:           begin,
+		Check:           check,
+		Expire:          int64(d.Get("expire").(int)),
+		ExpireOnResolve: d.Get("expire_on_resolve").(bool),
+		Reason:          d.Get("reason").(string),
+		Subscription:    subscription,
+	}
+
+	log.Printf("[DEBUG] Creating silenced %s: %#v", name, silenced)
+
+	if err := silenced.Validate(); err != nil {
+		return fmt.Errorf("Invalid silenced %s: %s", name, err)
+	}
+
+	if err := config.client.CreateSilenced(silenced); err != nil {
+		return fmt.Errorf("Unable to create silenced %s: %s", name, err)
+	}
+
+	d.SetId(name)
+
+	return resourceSilencedRead(d, meta)
+}
+
+func resourceSilencedRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	config.SaveNamespace(config.determineNamespace(d))
+	name := d.Id()
+
+	silenced, err := config.client.FetchSilenced(name)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve silenced %s: %s", name, err)
+	}
+
+	log.Printf("[DEBUG] Retrieved silenced %s: %#v", name, silenced)
+
+	d.Set("name", name)
+	d.Set("namespace", silenced.ObjectMeta.Namespace)
+	d.Set("annotations", silenced.ObjectMeta.Annotations)
+	d.Set("begin", silenced.Begin)
+	d.Set("check", silenced.Check)
+	d.Set("expire", silenced.Expire)
+	d.Set("labels", silenced.ObjectMeta.Labels)
+	d.Set("reason", silenced.Reason)
+	d.Set("resolve", silenced.ExpireOnResolve)
+	d.Set("subscription", silenced.Subscription)
+
+	return nil
+}
+
+func resourceSilencedUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	config.SaveNamespace(config.determineNamespace(d))
+	name := d.Id()
+
+	silenced, err := config.client.FetchSilenced(name)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve silenced %s: %s", name, err)
+	}
+
+	log.Printf("[DEBUG] Retrieved silenced %s: %#v", name, silenced)
+
+	if d.HasChange("annotations") {
+		silenced.ObjectMeta.Annotations = expandAnnotations(d.Get("annotations").(map[string]interface{}))
+	}
+
+	if d.HasChange("labels") {
+		silenced.ObjectMeta.Labels = expandLabels(d.Get("labels").(map[string]interface{}))
+	}
+
+	if d.HasChange("begin") {
+		begin, err := beginConvertToTimestamp(d.Get("begin").(string))
+		if err != nil {
+			return err
+		}
+		silenced.Begin = begin
+	}
+	if d.HasChange("check") {
+		silenced.Check = d.Get("check").(string)
+	}
+	if d.HasChange("creator") {
+		silenced.Creator = d.Get("creator").(string)
+	}
+	if d.HasChange("expire") {
+		silenced.Expire = int64(d.Get("expire").(int))
+	}
+	if d.HasChange("reason") {
+		silenced.Reason = d.Get("reason").(string)
+	}
+	if d.HasChange("resolve") {
+		silenced.ExpireOnResolve = d.Get("expire_on_resolve").(bool)
+	}
+	if d.HasChange("subscription") {
+		silenced.Subscription = d.Get("subscription").(string)
+	}
+
+	log.Printf("[DEBUG] Updating silenced %s: %#v", name, silenced)
+
+	if err := silenced.Validate(); err != nil {
+		return fmt.Errorf("Invalid silenced %s: %s", name, err)
+	}
+
+	if err := config.client.UpdateSilenced(silenced); err != nil {
+		return fmt.Errorf("Unable to update silenced %s: %s", name, err)
+	}
+
+	return resourceSilencedRead(d, meta)
+}
+
+func resourceSilencedDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	config.SaveNamespace(config.determineNamespace(d))
+	name := d.Id()
+
+	_, err := config.client.FetchSilenced(name)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve silenced %s: %s", name, err)
+	}
+
+	if err := config.client.DeleteSilenced(config.namespace, name); err != nil {
+		return fmt.Errorf("Unable to delete silenced %s: %s", name, err)
+	}
+
+	return nil
+}
+
+func beginConvertToTimestamp(begin string) (int64, error) {
+	if begin == "now" {
+		return time.Now().Unix(), nil
+	} else {
+		timestamp, err := timeutil.ConvertToUnix(begin)
+		if err != nil {
+			return 0, fmt.Errorf("Unable to convert begin date to timestamp %s: %s", begin, err)
+		}
+		return timestamp, nil
+	}
+}

--- a/sensu/resource_silenced_test.go
+++ b/sensu/resource_silenced_test.go
@@ -1,0 +1,53 @@
+package sensu
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccResourceSilenced_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccResourceSilenced_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"sensu_silenced.silenced_1", "check", "check_1"),
+					resource.TestCheckResourceAttr(
+						"sensu_silenced.silenced_1", "subscription", "subscription_1"),
+					resource.TestCheckResourceAttr(
+						"sensu_silenced.silenced_1", "begin", "now"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccResourceSilenced_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"sensu_silenced.silenced_1", "check", "check_1"),
+					resource.TestCheckResourceAttr(
+						"sensu_silenced.silenced_1", "subscription", "subscription_1"),
+					resource.TestCheckResourceAttr(
+						"sensu_silenced.silenced_1", "begin", "Jan 02 2020 3:04PM MST"),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceSilenced_basic = `
+  resource "sensu_silenced" "silenced_1" {
+    check = "check_1"
+    subscription = "subscription_1"
+  }
+`
+
+const testAccResourceSilenced_update = `
+  resource "sensu_silenced" "silenced_1" {
+    check = "check_1"
+    subscription = "subscription_1"
+    begin = "Jan 02 2020 3:04PM MST"
+  }
+`


### PR DESCRIPTION
Hi @jtopjian 

Adding support of sensu silencing. 

> Sensu’s silencing capability allows you to suppress event handler execution on an ad hoc basis so you can plan maintenance and reduce alert fatigue.

[More info](https://docs.sensu.io/sensu-go/latest/reference/silencing/)