### PR TITLE
asset: headers can be defined at top level or in each build

### DIFF
--- a/docs/resources/asset.md
+++ b/docs/resources/asset.md
@@ -46,14 +46,14 @@ resource "sensu_asset" "asset_1" {
   also be set with the `SENSU_NAMESPACE` environment variable. If not set,
   this defaults to `default`.
 
-* `build` - *Optional* - Defines a build for an asset. Define more than one `build` block for
+* `build` - *Required, if `url`, `sha512` and `filters` are not provided* - Defines a build for an asset. Define more than one `build` block for
   multiple-build assets
 
-* `sha512` - *Optional* - See the [Sensu asset reference](https://docs.sensu.io/sensu-go/latest/reference/assets).
+* `sha512` - *Required, unless `builds` are provided* - See the [Sensu asset reference](https://docs.sensu.io/sensu-go/latest/reference/assets).
   This was for single-build assets which have been deprecated. It is recommended to use the `build` block
   for multiple-build assets.
 
-* `url` - *Optional* - See the [Sensu asset reference](https://docs.sensu.io/sensu-go/latest/reference/assets).
+* `url` - *Required, unless `builds` are provided* - See the [Sensu asset reference](https://docs.sensu.io/sensu-go/latest/reference/assets).
   This was for single-build assets which have been deprecated. It is recommended to use the `build` block
   for multiple-build assets.
 
@@ -62,8 +62,6 @@ resource "sensu_asset" "asset_1" {
   for multiple-build assets.
 
 * `headers` - *Optional* - See the [Sensu asset reference](https://docs.sensu.io/sensu-go/latest/reference/assets).
-  This was for single-build assets which have been deprecated. It is recommended to use the `build` block
-  for multiple-build assets.
 
 ### build
 

--- a/sensu/resource_asset.go
+++ b/sensu/resource_asset.go
@@ -61,11 +61,8 @@ func resourceAsset() *schema.Resource {
 			},
 
 			"headers": &schema.Schema{
-				Type:          schema.TypeMap,
-				Optional:      true,
-				ConflictsWith: []string{"build"},
-				Deprecated: "This field is for single-build assets, " +
-					"which have been deprecated. Please use multiple-build assets instead.",
+				Type:     schema.TypeMap,
+				Optional: true,
 			},
 
 			"namespace": resourceNamespaceSchema,

--- a/sensu/resource_asset_test.go
+++ b/sensu/resource_asset_test.go
@@ -98,7 +98,7 @@ func TestAccResourceAsset_createMultipleBuild(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sensu_asset.asset_1", "build.0.filters.0", "entity.system.os == 'linux'"),
 					resource.TestCheckResourceAttr(
-						"sensu_asset.asset_1", "build.0.url", "https://example.com/asset_0.2.0.tar.gz"),
+						"sensu_asset.asset_1", "build.0.url", "https://example.com/asset_0.2.0_rhel.tar.gz"),
 				),
 			},
 		},
@@ -200,6 +200,9 @@ const testAccResourceAsset_createMultipleBuild_1 = `
 				"entity.system.platform_family == 'rhel'",
 				"parseInt(entity.system.platform_version.split('.')[0]) == 6",
 			]
+                	headers = {
+                        	"Authorization" = "Bearer changeme"
+                	}
 		}
 
 		build {
@@ -210,6 +213,9 @@ const testAccResourceAsset_createMultipleBuild_1 = `
 				"entity.system.arch == 'amd64'",
 				"entity.system.platform_family == 'debian'",
 			]
+                	headers = {
+                        	"Authorization" = "Bearer changeme"
+                	}
 		}
 	}
 `
@@ -228,7 +234,7 @@ const testAccResourceAsset_createMultipleBuild_2 = `
 		}
 
 		build {
-			url = "https://example.com/asset_0.2.0.tar.gz"
+			url = "https://example.com/asset_0.2.0_rhel.tar.gz"
 			sha512 = "cbee19124b7007342ce37ff9dfd4a1dde03beb1e87e61ca2aef606a7ad3c9bd0bba4e53873c07afa5ac46b0861967a9224511b4504dadb1a5e8fb687e9495304"
 			filters = [
 				"entity.system.os == 'linux'",
@@ -239,13 +245,17 @@ const testAccResourceAsset_createMultipleBuild_2 = `
 		}
 
 		build {
-			url = "https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.20_ruby-2.4.4_debian_linux_amd64.tar.gz"
+			url = "https://example.com/asset_0.2.0_debian.tar.gz"
 			sha512 = "a28952fd93fc63db1f8988c7bc40b0ad815eb9f35ef7317d6caf5d77ecfbfd824a9db54184400aa0c81c29b34cb48c7e8c6e3f17891aaf84cafa3c134266a61a"
 			filters = [
 				"entity.system.os == 'linux'",
 				"entity.system.arch == 'amd64'",
 				"entity.system.platform_family == 'debian'",
 			]
+		}
+
+		headers = {
+			"Authorization" = "Bearer changeme"
 		}
 	}
 `

--- a/sensu/shared.go
+++ b/sensu/shared.go
@@ -396,7 +396,7 @@ var resourceAssetBuildsSchema = &schema.Schema{
 	Type:          schema.TypeList,
 	Optional:      true,
 	ForceNew:      true,
-	ConflictsWith: []string{"url", "sha512", "filters", "headers"},
+	ConflictsWith: []string{"url", "sha512", "filters"},
 	Elem: &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"sha512": &schema.Schema{


### PR DESCRIPTION
when you want to upload a multi-build asset in the same asset repo, thus, with the same authentication, it is more simple to define the header only once (and not in each build).
sensu accepts this syntax.
And the official sensu doc is demonstrating this.

This merge request allow this simplified usage of multi-buil assets.