### PR TITLE
Removed the concept of edition

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,9 +36,6 @@ The following arguments are supported:
 * `namespace` - *Optional* - The namespace to manage resources in. This can
   also be set with the `SENSU_NAMESPACE` environment variable. If not set,
   this defaults to `default`.
-
-* `edition` - *Optional* - The edition of the Sensu service. This can also
-  be set with the `SENSU_EDITION` environment variable.
   
 * `trusted_ca_file` - *Optional* - Specify a file to be used as a trusted CA
   certificate. This can also be set with the `SENSU_TRUSTED_CA_FILE` environment

--- a/sensu/config.go
+++ b/sensu/config.go
@@ -25,9 +25,6 @@ type Config struct {
 	// password is the password.
 	password string
 
-	// edition is the sensu edition.
-	edition string
-
 	// namespace is the sensu namespace.
 	namespace string
 

--- a/sensu/provider.go
+++ b/sensu/provider.go
@@ -34,11 +34,6 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("SENSU_NAMESPACE", ""),
 			},
 
-			"edition": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SENSU_EDITION", ""),
-			},
 			"trusted_ca_file": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -96,7 +91,6 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		apiUrl:                d.Get("api_url").(string),
 		username:              d.Get("username").(string),
 		password:              d.Get("password").(string),
-		edition:               d.Get("edition").(string),
 		namespace:             d.Get("namespace").(string),
 		trustedCAFile:         d.Get("trusted_ca_file").(string),
 		insecureSkipTLSVerify: d.Get("insecure_skip_tls_verify").(bool),


### PR DESCRIPTION
Hi, 

I see that the edition parameter have been removed from sensu-go cli, [2 years ago](https://github.com/sensu/sensu-go/pull/2768/files#diff-01054755e11fb49f74e9296dfae724e45c0ba6c4240424106030b0dd54c364c3L40).

So, we can remove it too.